### PR TITLE
PHPStan types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         }
     ],
     "require": {
-        "php": ">=7.1"
+        "php": ">=7.2"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.0@dev"
+        "symfony/phpunit-bridge": "^7.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/RetryConfigurator.php
+++ b/src/RetryConfigurator.php
@@ -15,17 +15,17 @@ use Tobion\Retry\ExceptionHandler\RethrowOnMaxRetries;
 final class RetryConfigurator
 {
     /**
-     * @var string[]
+     * @var class-string<\Throwable>[]
      */
     private $retryableExceptionClasses = [];
 
     /**
-     * @var int
+     * @var int<0,max>
      */
     private $maxRetries;
 
     /**
-     * @var int
+     * @var int<0,max>
      */
     private $delayInMs = 0;
 
@@ -35,6 +35,8 @@ final class RetryConfigurator
      * - The callable is retried twice (i.e. max three executions). If it still fails, the last error is rethrown.
      * - Retries have a no delay between them.
      * - Every \Throwable will trigger the retry logic, i.e. both \Exception and \Error.
+     *
+     * @param int<0,max> $maxRetries
      */
     public function __construct(int $maxRetries = 2)
     {
@@ -49,6 +51,9 @@ final class RetryConfigurator
      *
      * For example, for handling database deadlocks and timeouts with Doctrine, it makes sense to configure `\Doctrine\DBAL\Exception\RetryableException`.
      *
+     * @param class-string<\Throwable> $exceptionClass
+     * @param class-string<\Throwable> $moreExceptionClasses
+     *
      * @return $this
      */
     public function retryOnSpecificExceptions(string $exceptionClass, string ...$moreExceptionClasses): self
@@ -61,6 +66,8 @@ final class RetryConfigurator
 
     /**
      * Sets the maximum number of retries.
+     *
+     * @param int<0,max> $maxRetries
      *
      * @return $this
      */
@@ -76,6 +83,8 @@ final class RetryConfigurator
      *
      * Set to zero to disable delay.
      *
+     * @param int<0,max> $milliseconds
+     *
      * @return $this
      */
     public function delayInMs(int $milliseconds): self
@@ -87,6 +96,12 @@ final class RetryConfigurator
 
     /**
      * Returns a callable that decorates the given operation that should be retried on failure.
+     *
+     * @template TResult
+     *
+     * @param callable():TResult $operation
+     *
+     * @return RetryingCallable<TResult>
      */
     public function decorate(callable $operation): RetryingCallable
     {
@@ -109,7 +124,12 @@ final class RetryConfigurator
     /**
      * Executes the passed callable and its arguments with the configured retry behavior.
      *
-     * @return mixed The return value of the passed callable
+     * @template TResult
+     *
+     * @param callable():TResult $operation
+     * @param mixed              $arguments
+     *
+     * @return TResult The return value of the passed callable
      */
     public function call(callable $operation, ...$arguments)
     {

--- a/src/RetryingCallable.php
+++ b/src/RetryingCallable.php
@@ -7,30 +7,32 @@ namespace Tobion\Retry;
  *
  * @author Tobias Schultze <http://tobion.de>
  * @author Christian Riesen <http://christianriesen.com>
+ *
+ * @template TResult
  */
 final class RetryingCallable
 {
     /**
-     * @var callable
+     * @var callable():TResult
      */
     private $operation;
 
     /**
-     * @var int
+     * @var int<0,max>
      */
     private $retries = 0;
 
     /**
-     * @var callable
+     * @var callable(\Throwable):void
      */
     private $exceptionHandler;
 
     /**
      * Constructor to wrap a callable operation.
      *
-     * @param callable $operation        The operation to execute that should be retried on failure
-     * @param callable $exceptionHandler A callback to execute when an exception is caught. The callback receives the exception
-     *                                   as parameter and can then decide what to do.
+     * @param callable():TResult        $operation        The operation to execute that should be retried on failure
+     * @param callable(\Throwable):void $exceptionHandler A callback to execute when an exception is caught. The callback receives the exception
+     *                                                    as parameter and can then decide what to do.
      */
     public function __construct(callable $operation, callable $exceptionHandler)
     {
@@ -40,6 +42,8 @@ final class RetryingCallable
 
     /**
      * Returns the number of retries used.
+     *
+     * @return int<0,max>
      */
     public function getRetries(): int
     {
@@ -51,7 +55,7 @@ final class RetryingCallable
      *
      * All arguments given will be passed through to the wrapped callable.
      *
-     * @return mixed The return value of the wrapped callable
+     * @return TResult The return value of the wrapped callable
      *
      * @throws \Throwable When the exception handler also throws an exception.
      */


### PR DESCRIPTION
Improve type information for PHPStan.

Tests pass:

```
$ vendor/bin/simple-phpunit 
PHPUnit 9.6.29 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.14
Configuration: /home/chris.smith/src/retry/phpunit.xml
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing 
..........                                                        10 / 10 (100%)

Time: 00:01.007, Memory: 6.00 MB

OK (10 tests, 18 assertions)
```