### PR TITLE
Permit callable arguments to be understood

### DIFF
--- a/src/RetryConfigurator.php
+++ b/src/RetryConfigurator.php
@@ -98,8 +98,9 @@ final class RetryConfigurator
      * Returns a callable that decorates the given operation that should be retried on failure.
      *
      * @template TResult
+     * @template TArgs
      *
-     * @param callable():TResult $operation
+     * @param callable(TArgs):TResult $operation
      *
      * @return RetryingCallable<TResult>
      */
@@ -125,8 +126,9 @@ final class RetryConfigurator
      * Executes the passed callable and its arguments with the configured retry behavior.
      *
      * @template TResult
+     * @template TArgs
      *
-     * @param callable():TResult $operation
+     * @param callable(TArgs):TResult $operation
      *
      * @return TResult The return value of the passed callable
      */

--- a/src/RetryingCallable.php
+++ b/src/RetryingCallable.php
@@ -9,11 +9,12 @@ namespace Tobion\Retry;
  * @author Christian Riesen <http://christianriesen.com>
  *
  * @template TResult
+ * @template TArgs
  */
 final class RetryingCallable
 {
     /**
-     * @var callable():TResult
+     * @var callable(TArgs):TResult
      */
     private $operation;
 
@@ -30,7 +31,7 @@ final class RetryingCallable
     /**
      * Constructor to wrap a callable operation.
      *
-     * @param callable():TResult        $operation        The operation to execute that should be retried on failure
+     * @param callable(TArgs):TResult   $operation        The operation to execute that should be retried on failure
      * @param callable(\Throwable):void $exceptionHandler A callback to execute when an exception is caught. The callback receives the exception
      *                                                    as parameter and can then decide what to do.
      */
@@ -54,6 +55,8 @@ final class RetryingCallable
      * Executes the wrapped callable and retries it until the exception handler also throws an exception.
      *
      * All arguments given will be passed through to the wrapped callable.
+     *
+     * @param TArgs ...$arguments
      *
      * @return TResult The return value of the wrapped callable
      *


### PR DESCRIPTION
I forgot to add this into #4.

Upgrading to 1.1 seeing PHPStan errors when decorating a callable which has arguments:

```
Parameter #1 $operation of method Tobion\Retry\RetryConfigurator::decorate() expects callable(): void, Closure(bool): void given.
```

This fixes them.
